### PR TITLE
Make table() work for commands such as aggregate

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,4 +29,4 @@ function require(relPath) {
 
     __modules.table_view['init.js'](internals);
 
-})({ DBQuery: DBQuery });
+})({ DBQuery: DBQuery, DBCommandCursor: DBCommandCursor });

--- a/lib/init.js
+++ b/lib/init.js
@@ -14,9 +14,11 @@
     'use strict';
 
     var tabularView = require('./tableView.js');
-
-    // support for .table() method on cursors
-    internal.DBQuery.prototype.table = function(opts) {
+    var table = function(opts) {
         return tabularView.apply(this, [opts]);
     };
+
+    // support for .table() method on cursors, including DBCommandCursor used by aggregation
+    internal.DBQuery.prototype.table = table;
+    internal.DBCommandCursor.prototype.table = table;
 });


### PR DESCRIPTION
Hi Charlie,

Now I can do things like:

```
  db.raw.aggregate([{$unwind: "$singledb"},
                    {$project: {id:1, server_git_hash:1, server_storage_engine:1, singledb:1 }}]
                  ).table()
```

Regards,
  -Geert

PS. The above is for the `bench_results` databases created by  `mongo-perf` 
